### PR TITLE
upgrading to 0.18 w/ one failing test

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# http://editorconfig.org/
+
+root = true
+
+
+[*.elm]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/Examples/Browse/Maybe.elm
+++ b/Examples/Browse/Maybe.elm
@@ -2,52 +2,81 @@ module Examples.Browse.Maybe exposing (..)
 
 import Pivot as P exposing (Pivot)
 
-type alias Model = Maybe (Pivot Artist)
 
-type alias Artist = String
+type alias Model =
+    Maybe (Pivot Artist)
+
+
+type alias Artist =
+    String
+
+
 
 -- We start without any artists.
+
+
 init : Model
 init =
-  Nothing
+    Nothing
+
 
 type Msg
-  = Next
-  | Previous
-  | Remove
-  | Add Artist
-  | MoveItemUp
-  | MoveItemDown
-  -- etc...
+    = Next
+    | Previous
+    | Remove
+    | Add Artist
+    | MoveItemUp
+    | MoveItemDown
+
+
+
+-- etc...
+
 
 update : Msg -> Model -> Model
 update msg model =
-  case msg of
-    Next ->
-      -- Attempt to go forward, rollback if can't.
-      model
-      |> Maybe.map (P.withRollback P.goR)
-    Previous ->
-      -- Attempt to go back, rollback if can't.
-      model
-      |> Maybe.map (P.withRollback P.goL)
-    Remove ->
-      case model `Maybe.andThen` P.removeGoL of -- Attempt to go back after.
-        Just collection ->
-          Just collection
-        Nothing ->
-          model `Maybe.andThen` P.removeGoR -- Attempt to go forward otherwise.
-    Add item ->
-      model
-      |> Maybe.map (P.addGoR item) -- Attempt to add to an existing collection.
-      |> Maybe.withDefault (P.pure item) -- Start from scratch otherwise.
-      |> Just -- Make the collection a `Maybe` again.
-    MoveItemUp ->
-      -- Attempt to move item up, rollback if can't.
-      model
-      |> Maybe.map (P.withRollback P.switchR)
-    MoveItemDown ->
-      -- Attempt to move item down, rollback if can't.
-      model
-      |> Maybe.map (P.withRollback P.switchL)
-    -- etc...
+    case msg of
+        Next ->
+            -- Attempt to go forward, rollback if can't.
+            model
+                |> Maybe.map (P.withRollback P.goR)
+
+        Previous ->
+            -- Attempt to go back, rollback if can't.
+            model
+                |> Maybe.map (P.withRollback P.goL)
+
+        Remove ->
+            case model |> Maybe.andThen P.removeGoL of
+                -- Attempt to go back after.
+                Just collection ->
+                    Just collection
+
+                Nothing ->
+                    model |> Maybe.andThen P.removeGoR
+
+        -- Attempt to go forward otherwise.
+        Add item ->
+            model
+                |> Maybe.map (P.addGoR item)
+                -- Attempt to add to an existing collection.
+                |>
+                    Maybe.withDefault (P.pure item)
+                -- Start from scratch otherwise.
+                |>
+                    Just
+
+        -- Make the collection a `Maybe` again.
+        MoveItemUp ->
+            -- Attempt to move item up, rollback if can't.
+            model
+                |> Maybe.map (P.withRollback P.switchR)
+
+        MoveItemDown ->
+            -- Attempt to move item down, rollback if can't.
+            model
+                |> Maybe.map (P.withRollback P.switchL)
+
+
+
+-- etc...

--- a/Examples/Undo/Entire.elm
+++ b/Examples/Undo/Entire.elm
@@ -2,63 +2,84 @@ module Examples.Undo.Entire exposing (..)
 
 import Pivot as P exposing (Pivot)
 
+
 -- This was the model before.
+
+
 type alias Counters =
-  { counter1 : Int
-  , counter2 : Int
-  }
+    { counter1 : Int
+    , counter2 : Int
+    }
+
 
 initRec : Counters
 initRec =
-  { counter1 = 0
-  , counter2 = 0
-  }
+    { counter1 = 0
+    , counter2 = 0
+    }
+
 
 type RecMsg
-  = NoOp
-  | Inc1
-  | Inc2
+    = NoOp
+    | Inc1
+    | Inc2
+
+
 
 -- This was the update function before.
+
+
 updateRec : RecMsg -> Counters -> Counters
 updateRec msgRec rec =
-  case msgRec of
-    Inc1 ->
-      { rec | counter1 = rec.counter1 + 1 }
-    Inc2 ->
-      { rec | counter2 = rec.counter2 + 1 }
-    NoOp ->
-      rec
+    case msgRec of
+        Inc1 ->
+            { rec | counter1 = rec.counter1 + 1 }
+
+        Inc2 ->
+            { rec | counter2 = rec.counter2 + 1 }
+
+        NoOp ->
+            rec
+
+
 
 -- Now we wrap it all in a pivot.
-type alias Model = Pivot Counters
+
+
+type alias Model =
+    Pivot Counters
+
 
 init : Model
 init =
-  initRec
-  |> P.pure
+    initRec
+        |> P.pure
+
 
 type Msg
-  = New RecMsg
-  | Undo
-  | Redo
+    = New RecMsg
+    | Undo
+    | Redo
+
 
 update : Msg -> Model -> Model
 update msg model =
-  case msg of
-    Undo ->
-      model
-      |> P.withRollback P.goL
-    Redo ->
-      model
-      |> P.withRollback P.goR
-    New msgRec ->
-      let
-        -- Creating the next state.
-        next =
-          P.getC model
-          |> updateRec msgRec
-      in
-        -- Adding the next state.
-        model
-        |> P.addGoR next
+    case msg of
+        Undo ->
+            model
+                |> P.withRollback P.goL
+
+        Redo ->
+            model
+                |> P.withRollback P.goR
+
+        New msgRec ->
+            let
+                -- Creating the next state.
+                next =
+                    P.getC model
+                        |> updateRec msgRec
+            in
+                -- Adding the next state.
+                model
+                    |> P.addGoR next

--- a/Examples/Undo/Partial.elm
+++ b/Examples/Undo/Partial.elm
@@ -2,56 +2,67 @@ module Examples.Undo.Partial exposing (..)
 
 import Pivot as P exposing (Pivot)
 
-type alias Counter1Model = Pivot Int
+
+type alias Counter1Model =
+    Pivot Int
+
 
 type alias Model =
-  { counter1 : Counter1Model
-  , counter2 : Int
-  }
+    { counter1 : Counter1Model
+    , counter2 : Int
+    }
+
 
 init : Model
 init =
-  { counter1 = P.pure 0
-  , counter2 = 0
-  }
+    { counter1 = P.pure 0
+    , counter2 = 0
+    }
+
 
 type Msg
-  = Counter1 Counter1Msg
-  | Counter2
+    = Counter1 Counter1Msg
+    | Counter2
+
 
 update : Msg -> Model -> Model
 update msg model =
-  case msg of
-    Counter1 counter1Msg ->
-      { model
-      | counter1 =
-        model.counter1
-        |> counter1Update counter1Msg
-      }
-    Counter2 ->
-      { model
-      | counter2 =
-        model.counter2 + 1
-      }
+    case msg of
+        Counter1 counter1Msg ->
+            { model
+                | counter1 =
+                    model.counter1
+                        |> counter1Update counter1Msg
+            }
+
+        Counter2 ->
+            { model
+                | counter2 =
+                    model.counter2 + 1
+            }
+
 
 type Counter1Msg
-  = Inc
-  | Undo
-  | Redo
+    = Inc
+    | Undo
+    | Redo
+
 
 counter1Update : Counter1Msg -> Counter1Model -> Counter1Model
 counter1Update counter1Msg counter1 =
-  case counter1Msg of
-    Inc ->
-      let
-        next =
-          P.getC counter1 + 1
-      in
-        counter1
-        |> P.addGoR next
-    Undo ->
-      counter1
-      |> P.withRollback P.goL
-    Redo ->
-      counter1
-      |> P.withRollback P.goR
+    case counter1Msg of
+        Inc ->
+            let
+                next =
+                    P.getC counter1 + 1
+            in
+                counter1
+                    |> P.addGoR next
+
+        Undo ->
+            counter1
+                |> P.withRollback P.goL
+
+        Redo ->
+            counter1
+                |> P.withRollback P.goR

--- a/Examples/Undo/Without.elm
+++ b/Examples/Undo/Without.elm
@@ -1,27 +1,33 @@
 module Examples.Undo.Without exposing (..)
 
+
 type alias Model =
-  { counter1 : Int
-  , counter2 : Int
-  }
+    { counter1 : Int
+    , counter2 : Int
+    }
+
 
 init : Model
 init =
-  { counter1 = 0
-  , counter2 = 0
-  }
+    { counter1 = 0
+    , counter2 = 0
+    }
+
 
 type Msg
-  = NoOp
-  | Inc1
-  | Inc2
+    = NoOp
+    | Inc1
+    | Inc2
+
 
 update : Msg -> Model -> Model
 update msg model =
-  case msg of
-    Inc1 ->
-      { model | counter1 = model.counter1 + 1 }
-    Inc2 ->
-      { model | counter2 = model.counter2 + 1 }
-    NoOp ->
-      model
+    case msg of
+        Inc1 ->
+            { model | counter1 = model.counter1 + 1 }
+
+        Inc2 ->
+            { model | counter2 = model.counter2 + 1 }
+
+        NoOp ->
+            model

--- a/Pivot.elm
+++ b/Pivot.elm
@@ -1,6 +1,4 @@
-module Pivot exposing
-  (..)
-
+module Pivot exposing (..)
 
 {-| A pivot is a list upgraded with a center and sides. However, a pivot
 can never be empty, so it is better to think of it an upgraded cons list.
@@ -26,7 +24,7 @@ For example, `getL` gets the left side of a pivot.
 So you want to use a pivot? Better know how to create one, and get stuff back!
 
 ## Create
-@docs fromList, fromCons, pure
+@docs fromList, fromCons, singleton
 
 ## Get
 @docs getC, getL, getR, getA, hasL, hasR
@@ -84,8 +82,8 @@ then you must retain the type.
 ## As a whole
 Some `List a -> List a` functions cannot be made from `a -> a` functions.
 This is why these maps may be of importance.
-Just add `'` to a `map*` function to use functions on lists instead of values.
-@docs mapCLR', mapCRL', mapCS', mapS', mapL', mapR'
+Just add `_` to a `map*` function to use functions on lists instead of values.
+@docs mapCLR_, mapCRL_, mapCS_, mapS_, mapL_, mapR_
 
 ## Special
 @docs zip, apply
@@ -93,7 +91,6 @@ Just add `'` to a `map*` function to use functions on lists instead of values.
 # Utilities
 @docs reverse, mirror, mirrorM, assert, withRollback
 -}
-
 
 import Pivot.Types
 import Pivot.Create as Create
@@ -107,7 +104,8 @@ import Pivot.Utilities as Utilities
 
 {-| Pivot is an opaque data type.
 -}
-type alias Pivot a = Pivot.Types.Pivot a
+type alias Pivot a =
+    Pivot.Types.Pivot a
 
 
 {-| Make a pivot from a list with empty left side.
@@ -117,7 +115,8 @@ _Fails if and only if the list given is empty._
     fromList [] == Nothing
 -}
 fromList : List a -> Maybe (Pivot a)
-fromList = Create.fromList
+fromList =
+    Create.fromList
 
 
 {-| Like `fromList`, but by specifying the center explicitly, it cannot fail.
@@ -128,53 +127,61 @@ fromList = Create.fromList
     Just (fromCons 1 [2..4]) == fromList [1..4]
 -}
 fromCons : a -> List a -> Pivot a
-fromCons = Create.fromCons
+fromCons =
+    Create.fromCons
 
 
 {-| Like `fromCons`, but without the list. That is, we specify only the center.
 
-    pure == flip fromCons []
+    singleton == flip fromCons []
 -}
-pure : a -> Pivot a
-pure = Create.pure
+singleton : a -> Pivot a
+singleton =
+    Create.singleton
 
 
 {-| Get the center member.
 
-    pure >> getC == identity
+    singleton >> getC == identity
 -}
 getC : Pivot a -> a
-getC = Get.getC
+getC =
+    Get.getC
 
 
 {-| Get the left side list.
 -}
 getL : Pivot a -> List a
-getL = Get.getL
+getL =
+    Get.getL
 
 
 {-| Get the right side list.
 -}
 getR : Pivot a -> List a
-getR = Get.getR
+getR =
+    Get.getR
 
 
 {-| Make the pivot into a list.
 -}
 getA : Pivot a -> List a
-getA = Get.getA
+getA =
+    Get.getA
 
 
 {-| Check if the left side is not empty.
 -}
 hasL : Pivot a -> Bool
-hasL = Get.hasL
+hasL =
+    Get.hasL
 
 
 {-| Check if the right side is not empty.
 -}
 hasR : Pivot a -> Bool
-hasR = Get.hasR
+hasR =
+    Get.hasR
 
 
 {-| Find the first member of a pivot satisfying some predicate.
@@ -182,7 +189,8 @@ hasR = Get.hasR
 _Fails if and only if there are no such members._
 -}
 firstWith : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
-firstWith = Find.firstWith
+firstWith =
+    Find.firstWith
 
 
 {-| Find the last member of a pivot satisfying some predicate.
@@ -190,17 +198,19 @@ firstWith = Find.firstWith
 _Fails if and only if there are no such members._
 -}
 lastWith : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
-lastWith = Find.lastWith
+lastWith =
+    Find.lastWith
 
 
 {-| Find the first member to the center's right satisfying some predicate.
 
 _Fails if and only if there are no such members._
 
-    findR ((==) 3) (fromCons 1 [2..4]) == (pure 3 |> setL [1, 2] |> setR [4])
+    findR ((==) 3) (fromCons 1 [2..4]) == (singleton 3 |> setL [1, 2] |> setR [4])
 -}
 findR : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
-findR = Find.findR
+findR =
+    Find.findR
 
 
 {-| Find the first member to the center's left satisfying some predicate.
@@ -208,7 +218,8 @@ findR = Find.findR
 _Fails if and only if there are no such members._
 -}
 findL : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
-findL = Find.findL
+findL =
+    Find.findL
 
 
 {-| Like `findR`, but checks the center first as well.
@@ -218,7 +229,8 @@ _Fails if and only if there are no such members._
     firstWith == \pred -> goToStart >> findCR pred
 -}
 findCR : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
-findCR = Find.findCR
+findCR =
+    Find.findCR
 
 
 {-| Like `findL`, but checks the center first as well.
@@ -226,7 +238,8 @@ findCR = Find.findCR
 _Fails if and only if there are no such members._
 -}
 findCL : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
-findCL = Find.findCL
+findCL =
+    Find.findCL
 
 
 {-| Move one step right.
@@ -239,7 +252,8 @@ and instead have a possible no-op. See __Utilities__.
     fromCons 1 [2..4] |> goR /= Nothing
 -}
 goR : Pivot a -> Maybe (Pivot a)
-goR = Position.goR
+goR =
+    Position.goR
 
 
 {-| Move one step left.
@@ -250,7 +264,8 @@ _Fails if and only if the left side is empty._
     withRollback goL (fromCons 1 [2..4]) == fromCons 1 [2..4]
 -}
 goL : Pivot a -> Maybe (Pivot a)
-goL = Position.goL
+goL =
+    Position.goL
 
 
 {-| Move right by some number of steps. Negative number moves left instead.
@@ -258,7 +273,8 @@ goL = Position.goL
 _Fails if and only if the movement goes out of bounds._
 -}
 goBy : Int -> Pivot a -> Maybe (Pivot a)
-goBy = Position.goBy
+goBy =
+    Position.goBy
 
 
 {-| Go to a specific position from the left. Starts with 0.
@@ -266,7 +282,8 @@ goBy = Position.goBy
 _Fails if and only if the position given doesn't exist._
 -}
 goTo : Int -> Pivot a -> Maybe (Pivot a)
-goTo = Position.goTo
+goTo =
+    Position.goTo
 
 
 {-| Go to starting position.
@@ -274,7 +291,8 @@ goTo = Position.goTo
     goToStart >> lengthL == 0
 -}
 goToStart : Pivot a -> Pivot a
-goToStart = Position.goToStart
+goToStart =
+    Position.goToStart
 
 
 {-| Go to starting position.
@@ -282,19 +300,22 @@ goToStart = Position.goToStart
     goToEnd >> lengthR == 0
 -}
 goToEnd : Pivot a -> Pivot a
-goToEnd = Position.goToEnd
+goToEnd =
+    Position.goToEnd
 
 
 {-| Position from the left side. Starts with 0.
 -}
 lengthL : Pivot a -> Int
-lengthL = Position.lengthL
+lengthL =
+    Position.lengthL
 
 
 {-| Position from the right side. Starts with 0.
 -}
 lengthR : Pivot a -> Int
-lengthR = Position.lengthR
+lengthR =
+    Position.lengthR
 
 
 {-| Length of the pivot.
@@ -302,25 +323,29 @@ lengthR = Position.lengthR
     lengthA == \p -> lengthL p + 1 + lengthR p
 -}
 lengthA : Pivot a -> Int
-lengthA = Position.lengthA
+lengthA =
+    Position.lengthA
 
 
 {-| Replace the center.
 -}
 setC : a -> Pivot a -> Pivot a
-setC = Modify.setC
+setC =
+    Modify.setC
 
 
 {-| Replace the left.
 -}
 setL : List a -> Pivot a -> Pivot a
-setL = Modify.setL
+setL =
+    Modify.setL
 
 
 {-| Replace the right.
 -}
 setR : List a -> Pivot a -> Pivot a
-setR = Modify.setR
+setR =
+    Modify.setR
 
 
 {-| Switch places with member nearest to the left
@@ -328,7 +353,8 @@ setR = Modify.setR
 _Fails if and only if left side is empty_
 -}
 switchL : Pivot a -> Maybe (Pivot a)
-switchL = Modify.switchL
+switchL =
+    Modify.switchL
 
 
 {-| Switch places with member nearest to the right
@@ -336,14 +362,17 @@ switchL = Modify.switchL
 _Fails if and only if right side is empty_
 -}
 switchR : Pivot a -> Maybe (Pivot a)
-switchR = Modify.switchR
+switchR =
+    Modify.switchR
+
 
 {-| Replace center with member nearest to the left.
 
 _Fails if and only if left side is empty._
 -}
 removeGoL : Pivot a -> Maybe (Pivot a)
-removeGoL = Modify.removeGoL
+removeGoL =
+    Modify.removeGoL
 
 
 {-| Replace center with member nearest to the right.
@@ -351,19 +380,22 @@ removeGoL = Modify.removeGoL
 _Fails if and only if right side is empty._
 -}
 removeGoR : Pivot a -> Maybe (Pivot a)
-removeGoR = Modify.removeGoR
+removeGoR =
+    Modify.removeGoR
 
 
 {-| Add a member to the left of the center
 -}
 addL : a -> Pivot a -> Pivot a
-addL = Modify.addL
+addL =
+    Modify.addL
 
 
 {-| Add a member to the right of the center
 -}
 addR : a -> Pivot a -> Pivot a
-addR = Modify.addR
+addR =
+    Modify.addR
 
 
 {-| Add a member to the left of the center and immediately move left.
@@ -373,13 +405,15 @@ We know that `addL >> goL` cannot really fail, but it still results in a
     addGoL >> Just == addL >> goL
 -}
 addGoL : a -> Pivot a -> Pivot a
-addGoL = Modify.addGoL
+addGoL =
+    Modify.addGoL
 
 
 {-| Add a member to the right of the center and immediately move right.
 -}
 addGoR : a -> Pivot a -> Pivot a
-addGoR = Modify.addGoR
+addGoR =
+    Modify.addGoR
 
 
 {-| Sort a pivot while keeping the center as center.
@@ -390,7 +424,8 @@ It does not simply sort each side separately!
     getC == sort >> getC
 -}
 sort : Pivot comparable -> Pivot comparable
-sort = Modify.sort
+sort =
+    Modify.sort
 
 
 {-| Like `sort`, but with a costum comparator.
@@ -398,7 +433,8 @@ sort = Modify.sort
     sort == sortWith compare
 -}
 sortWith : (a -> a -> Order) -> Pivot a -> Pivot a
-sortWith = Modify.sortWith
+sortWith =
+    Modify.sortWith
 
 
 {-| Provide functions that control what happens to the center,
@@ -406,19 +442,22 @@ the left members and the right member separately,
 and get a function that acts on pivots.
 -}
 mapCLR : (a -> b) -> (a -> b) -> (a -> b) -> Pivot a -> Pivot b
-mapCLR = Map.mapCLR
+mapCLR =
+    Map.mapCLR
 
 
 {-| Like `mapCLR`, but provide the function for the right before the left.
 -}
 mapCRL : (a -> b) -> (a -> b) -> (a -> b) -> Pivot a -> Pivot b
-mapCRL = Map.mapCRL
+mapCRL =
+    Map.mapCRL
 
 
 {-| Like `mapCLR`, but you provide one function for both sides.
 -}
 mapCS : (a -> b) -> (a -> b) -> Pivot a -> Pivot b
-mapCS = Map.mapCS
+mapCS =
+    Map.mapCS
 
 
 {-| Like `mapCS`, but you provide one function for all members.
@@ -427,75 +466,87 @@ This is exactly like `List.map` for the underlying list.
     mapA ((==) 3) (fromCons 1 [2..4]) == fromCons False [False, True, False]
 -}
 mapA : (a -> b) -> Pivot a -> Pivot b
-mapA = Map.mapA
+mapA =
+    Map.mapA
 
 
 {-| Like `mapA`, but only the center is affected.
 -}
 mapC : (a -> a) -> Pivot a -> Pivot a
-mapC = Map.mapC
+mapC =
+    Map.mapC
 
 
 {-| Like `mapA`, but only the left is affected.
 -}
 mapL : (a -> a) -> Pivot a -> Pivot a
-mapL = Map.mapL
+mapL =
+    Map.mapL
 
 
 {-| Like `mapA`, but only the right is affected.
 -}
 mapR : (a -> a) -> Pivot a -> Pivot a
-mapR = Map.mapR
+mapR =
+    Map.mapR
 
 
 {-| Like `mapA`, but the center is __not__ affected.
 -}
 mapS : (a -> a) -> Pivot a -> Pivot a
-mapS = Map.mapS
+mapS =
+    Map.mapS
 
 
 {-| Like `mapCLR`, but the functions for the left and right act on the
 lists as a whole, and not on each member separately.
 -}
-mapCLR' : (a -> b) -> (List a -> List b) -> (List a -> List b) -> Pivot a -> Pivot b
-mapCLR' = Map.mapCLR'
+mapCLR_ : (a -> b) -> (List a -> List b) -> (List a -> List b) -> Pivot a -> Pivot b
+mapCLR_ =
+    Map.mapCLR_
 
 
-{-| See `mapCLR'`.
+{-| See `mapCLR_`.
 -}
-mapCRL' : (a -> b) -> (List a -> List b) -> (List a -> List b) -> Pivot a -> Pivot b
-mapCRL' = Map.mapCRL'
+mapCRL_ : (a -> b) -> (List a -> List b) -> (List a -> List b) -> Pivot a -> Pivot b
+mapCRL_ =
+    Map.mapCRL_
 
 
-{-| See `mapCLR'`.
+{-| See `mapCLR_`.
 -}
-mapCS' : (a -> b) -> (List a -> List b) -> Pivot a -> Pivot b
-mapCS' = Map.mapCS'
+mapCS_ : (a -> b) -> (List a -> List b) -> Pivot a -> Pivot b
+mapCS_ =
+    Map.mapCS_
 
 
-{-| See `mapCLR'`.
+{-| See `mapCLR_`.
 -}
-mapL' : (List a -> List a) -> Pivot a -> Pivot a
-mapL' = Map.mapL'
+mapL_ : (List a -> List a) -> Pivot a -> Pivot a
+mapL_ =
+    Map.mapL_
 
 
-{-| See `mapCLR'`.
+{-| See `mapCLR_`.
 -}
-mapR' : (List a -> List a) -> Pivot a -> Pivot a
-mapR' = Map.mapR'
+mapR_ : (List a -> List a) -> Pivot a -> Pivot a
+mapR_ =
+    Map.mapR_
 
 
-{-| See `mapCLR'`.
+{-| See `mapCLR_`.
 -}
-mapS' : (List a -> List a) -> Pivot a -> Pivot a
-mapS' = Map.mapS'
+mapS_ : (List a -> List a) -> Pivot a -> Pivot a
+mapS_ =
+    Map.mapS_
 
 
 {-| Adds indices to the values.
 Based internally on `List.indexedMap`.
 -}
-zip : Pivot a -> Pivot (Int, a)
-zip = Map.zip
+zip : Pivot a -> Pivot ( Int, a )
+zip =
+    Map.zip
 
 
 {-| Apply functions in a pivot on values in another Pivot.
@@ -505,31 +556,35 @@ But how does a list of functions get applied on a list of values?
 Well, each function maps over the complete list of values,
 and then all the lists created from these applications are concatinated.
 
-    mapCLR onC onL onR == (pure onC |> setL [onL] |> setR [onR] |> apply)
+    mapCLR onC onL onR == (singleton onC |> setL [ onL ] |> setR [ onR ] |> apply)
 -}
 apply : Pivot (a -> b) -> Pivot a -> Pivot b
-apply = Map.apply
+apply =
+    Map.apply
 
 
 {-| Reverse a pivot, like a list. You could also think of it as mirroring
 left and right.
 -}
 reverse : Pivot a -> Pivot a
-reverse = Utilities.reverse
+reverse =
+    Utilities.reverse
 
 
 {-| Reverse a function's notion of left and right.
 Used in many of this library's functions under the hood
 -}
 mirror : (Pivot a -> Pivot b) -> Pivot a -> Pivot b
-mirror = Utilities.mirror
+mirror =
+    Utilities.mirror
 
 
 {-| Reverse a possibly-failing-function's notion of left and right.
 Used in many of this library's functions under the hood
 -}
 mirrorM : (Pivot a -> Maybe (Pivot b)) -> Pivot a -> Maybe (Pivot b)
-mirrorM = Utilities.mirrorM
+mirrorM =
+    Utilities.mirrorM
 
 
 {-| Takes a pivot full of possible values, and realizes it only if all
@@ -542,7 +597,8 @@ For example, you could define
     mapAM f = mapA f >> assert
 -}
 assert : Pivot (Maybe a) -> Maybe (Pivot a)
-assert = Utilities.assert
+assert =
+    Utilities.assert
 
 
 {-| Replace a possibly-failing-function with a possibly-does-nothing-function.
@@ -568,4 +624,5 @@ It might be useful to define infix operators as such.
     goR <! pvt == withRollback goR pvt
 -}
 withRollback : (a -> Maybe a) -> a -> a
-withRollback = Utilities.withRollback
+withRollback =
+    Utilities.withRollback

--- a/Pivot/Create.elm
+++ b/Pivot/Create.elm
@@ -1,6 +1,4 @@
-module Pivot.Create exposing
-  (..)
-
+module Pivot.Create exposing (..)
 
 import Pivot.Types exposing (..)
 import Pivot.Utilities exposing (..)
@@ -9,23 +7,25 @@ import Pivot.Get exposing (..)
 
 fromList : List a -> Maybe (Pivot a)
 fromList l =
-  case l of
-    hd :: tl ->
-      fromCons hd tl
-      |> Just
-    [] ->
-      Nothing
+    case l of
+        hd :: tl ->
+            fromCons hd tl
+                |> Just
+
+        [] ->
+            Nothing
 
 
 fromCons : a -> List a -> Pivot a
 fromCons x xs =
-  Pivot x ([], xs)
+    Pivot x ( [], xs )
 
 
-(!!) = fromCons
+(!!) =
+    fromCons
 infixr 5 !!
 
 
-pure : a -> Pivot a
-pure =
-  flip fromCons []
+singleton : a -> Pivot a
+singleton =
+    flip fromCons []

--- a/Pivot/Find.elm
+++ b/Pivot/Find.elm
@@ -1,6 +1,4 @@
-module Pivot.Find exposing
-  (..)
-
+module Pivot.Find exposing (..)
 
 import Pivot.Types exposing (..)
 import Pivot.Utilities exposing (..)
@@ -10,36 +8,35 @@ import Pivot.Position exposing (..)
 
 firstWith : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
 firstWith pred =
-  goToStart >> findCR pred
+    goToStart >> findCR pred
 
 
 lastWith : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
 lastWith pred =
-  firstWith pred
-  |> mirrorM
+    firstWith pred
+        |> mirrorM
 
 
 findCR : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
 findCR pred pvt =
-  if pvt |> getC |> pred
-    then
-      Just pvt
+    if pvt |> getC |> pred then
+        Just pvt
     else
-      goR pvt `Maybe.andThen` findCR pred
+        goR pvt |> Maybe.andThen (findCR pred)
 
 
 findR : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
 findR pred pvt =
-  goR pvt `Maybe.andThen` findCR pred
+    goR pvt |> Maybe.andThen (findCR pred)
 
 
 findCL : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
 findCL pred =
-  findCR pred
-  |> mirrorM
+    findCR pred
+        |> mirrorM
 
 
 findL : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
 findL pred =
-  findR pred
-  |> mirrorM
+    findR pred
+        |> mirrorM

--- a/Pivot/Get.elm
+++ b/Pivot/Get.elm
@@ -1,6 +1,4 @@
-module Pivot.Get exposing
-  (..)
-
+module Pivot.Get exposing (..)
 
 import Pivot.Types exposing (..)
 import Pivot.Utilities exposing (..)
@@ -8,29 +6,29 @@ import Pivot.Utilities exposing (..)
 
 getC : Pivot a -> a
 getC (Pivot c _) =
-  c
+    c
 
 
 getL : Pivot a -> List a
-getL (Pivot _ (l, _)) =
-  List.reverse l
+getL (Pivot _ ( l, _ )) =
+    List.reverse l
 
 
 hasL : Pivot a -> Bool
 hasL =
-  getL >> List.length >> flip (>) 0
+    getL >> List.length >> flip (>) 0
 
 
 getR : Pivot a -> List a
-getR (Pivot _ (_, r)) =
-  r
+getR (Pivot _ ( _, r )) =
+    r
 
 
 hasR : Pivot a -> Bool
 hasR =
-  reverse >> hasL
+    reverse >> hasL
 
 
 getA : Pivot a -> List a
-getA (Pivot c (l, r)) =
-  List.reverse l ++ c :: r
+getA (Pivot c ( l, r )) =
+    List.reverse l ++ c :: r

--- a/Pivot/Map.elm
+++ b/Pivot/Map.elm
@@ -1,6 +1,4 @@
-module Pivot.Map exposing
-  (..)
-
+module Pivot.Map exposing (..)
 
 import Pivot.Types exposing (..)
 import Pivot.Utilities exposing (..)
@@ -10,95 +8,98 @@ import Pivot.Position exposing (..)
 
 mapCLR : (a -> b) -> (a -> b) -> (a -> b) -> Pivot a -> Pivot b
 mapCLR onC onL onR =
-  mapCLR' onC (List.map onL) (List.map onR)
+    mapCLR_ onC (List.map onL) (List.map onR)
 
 
 mapCRL : (a -> b) -> (a -> b) -> (a -> b) -> Pivot a -> Pivot b
 mapCRL onC =
-  flip (mapCLR onC)
+    flip (mapCLR onC)
 
 
 mapCS : (a -> b) -> (a -> b) -> Pivot a -> Pivot b
 mapCS onC onS =
-  mapCLR onC onS onS
+    mapCLR onC onS onS
 
 
 mapA : (a -> b) -> Pivot a -> Pivot b
 mapA onA =
-  mapCS onA onA
+    mapCS onA onA
 
 
 mapC : (a -> a) -> Pivot a -> Pivot a
 mapC =
-  flip mapCS identity
+    flip mapCS identity
 
 
 mapL : (a -> a) -> Pivot a -> Pivot a
 mapL =
-  mapCRL identity identity
+    mapCRL identity identity
 
 
 mapR : (a -> a) -> Pivot a -> Pivot a
 mapR f =
-  mapL f
-  |> mirror
+    mapL f
+        |> mirror
 
 
 mapS : (a -> a) -> Pivot a -> Pivot a
 mapS =
-  mapCS identity
+    mapCS identity
 
 
-mapCLR' : (a -> b) -> (List a -> List b) -> (List a -> List b) -> Pivot a -> Pivot b
-mapCLR' onC' onL' onR' pvt =
-  Pivot (pvt |> getC |> onC') (pvt |> getL |> onL' |> List.reverse, pvt |> getR |> onR')
+mapCLR_ : (a -> b) -> (List a -> List b) -> (List a -> List b) -> Pivot a -> Pivot b
+mapCLR_ onC_ onL_ onR_ pvt =
+    Pivot (pvt |> getC |> onC_) ( pvt |> getL |> onL_ |> List.reverse, pvt |> getR |> onR_ )
 
 
-mapCRL' : (a -> b) -> (List a -> List b) -> (List a -> List b) -> Pivot a -> Pivot b
-mapCRL' onC' =
-  flip (mapCLR' onC')
+mapCRL_ : (a -> b) -> (List a -> List b) -> (List a -> List b) -> Pivot a -> Pivot b
+mapCRL_ onC_ =
+    flip (mapCLR_ onC_)
 
 
-mapCS' : (a -> b) -> (List a -> List b) -> Pivot a -> Pivot b
-mapCS' onC' onS' =
-  mapCLR' onC' onS' onS'
+mapCS_ : (a -> b) -> (List a -> List b) -> Pivot a -> Pivot b
+mapCS_ onC_ onS_ =
+    mapCLR_ onC_ onS_ onS_
 
 
-mapL' : (List a -> List a) -> Pivot a -> Pivot a
-mapL' =
-  mapCRL' identity identity
+mapL_ : (List a -> List a) -> Pivot a -> Pivot a
+mapL_ =
+    mapCRL_ identity identity
 
 
-mapR' : (List a -> List a) -> Pivot a -> Pivot a
-mapR' f =
-  mapL' f
-  |> mirror
+mapR_ : (List a -> List a) -> Pivot a -> Pivot a
+mapR_ f =
+    mapL_ f
+        |> mirror
 
 
-mapS' : (List a -> List a) -> Pivot a -> Pivot a
-mapS' =
-  mapCS' identity
+mapS_ : (List a -> List a) -> Pivot a -> Pivot a
+mapS_ =
+    mapCS_ identity
 
 
-zip : Pivot a -> Pivot (Int, a)
+zip : Pivot a -> Pivot ( Int, a )
 zip pvt =
-  let
-    n =
-      lengthL pvt
-    onC =
-      (,) n
-    onL =
-      List.indexedMap (,)
-    onR =
-      List.indexedMap ((+) (n+1) >> (,))
-  in
-    mapCLR' onC onL onR pvt
+    let
+        n =
+            lengthL pvt
+
+        onC =
+            (,) n
+
+        onL =
+            List.indexedMap (,)
+
+        onR =
+            List.indexedMap ((+) (n + 1) >> (,))
+    in
+        mapCLR_ onC onL onR pvt
 
 
 apply : Pivot (a -> b) -> Pivot a -> Pivot b
-apply (Pivot cf (lf, rf)) (Pivot c (l, r)) =
-  let
-    apList fs xs =
-      List.concatMap (flip List.map xs) fs
-  in
-    Pivot (cf c) (apList lf l, apList rf r)
+apply (Pivot cf ( lf, rf )) (Pivot c ( l, r )) =
+    let
+        apList fs xs =
+            List.concatMap (flip List.map xs) fs
+    in
+        Pivot (cf c) ( apList lf l, apList rf r )

--- a/Pivot/Modify.elm
+++ b/Pivot/Modify.elm
@@ -1,6 +1,4 @@
-module Pivot.Modify exposing
-  (..)
-
+module Pivot.Modify exposing (..)
 
 import Pivot.Types exposing (..)
 import Pivot.Utilities exposing (..)
@@ -9,85 +7,90 @@ import Pivot.Get exposing (..)
 
 
 setC : a -> Pivot a -> Pivot a
-setC c' (Pivot c (l, r)) =
-  Pivot c' (l, r)
+setC c_ (Pivot c ( l, r )) =
+    Pivot c_ ( l, r )
 
 
 setL : List a -> Pivot a -> Pivot a
-setL l' (Pivot c (l, r)) =
-  Pivot c (List.reverse l', r)
+setL l_ (Pivot c ( l, r )) =
+    Pivot c ( List.reverse l_, r )
 
 
 setR : List a -> Pivot a -> Pivot a
-setR r' =
-  setL r'
-  |> mirror
+setR r_ =
+    setL r_
+        |> mirror
 
 
 switchL : Pivot a -> Maybe (Pivot a)
 switchL pvt =
-  removeGoL pvt
-  |> Maybe.map (pvt |> getC |> addGoL)
+    removeGoL pvt
+        |> Maybe.map (pvt |> getC |> addGoL)
 
 
 switchR : Pivot a -> Maybe (Pivot a)
 switchR =
-  switchL
-  |> mirrorM
+    switchL
+        |> mirrorM
 
 
 removeGoL : Pivot a -> Maybe (Pivot a)
-removeGoL (Pivot c (l, r)) =
-  case l of
-    hd :: tl ->
-      Pivot hd (tl, r)
-      |> Just
-    [] ->
-      Nothing
+removeGoL (Pivot c ( l, r )) =
+    case l of
+        hd :: tl ->
+            Pivot hd ( tl, r )
+                |> Just
+
+        [] ->
+            Nothing
 
 
 removeGoR : Pivot a -> Maybe (Pivot a)
 removeGoR =
-  removeGoL
-  |> mirrorM
+    removeGoL
+        |> mirrorM
 
 
 addL : a -> Pivot a -> Pivot a
-addL val (Pivot c (l, r)) =
-  Pivot c (val :: l, r)
+addL val (Pivot c ( l, r )) =
+    Pivot c ( val :: l, r )
 
 
 addR : a -> Pivot a -> Pivot a
 addR val =
-  addL val
-  |> mirror
+    addL val
+        |> mirror
 
 
 addGoL : a -> Pivot a -> Pivot a
-addGoL val (Pivot c (l, r)) =
-  Pivot val (l, c :: r)
+addGoL val (Pivot c ( l, r )) =
+    Pivot val ( l, c :: r )
 
 
 addGoR : a -> Pivot a -> Pivot a
 addGoR val =
-  addGoL val
-  |> mirror
+    addGoL val
+        |> mirror
 
 
 sort : Pivot comparable -> Pivot comparable
 sort =
-  sortWith compare
+    sortWith compare
 
 
 sortWith : (a -> a -> Order) -> Pivot a -> Pivot a
-sortWith compare (Pivot c (l, r)) =
-  let
-    folder item (l', r') =
-      case compare item c of
-        GT -> (l', item :: r')
-        _ -> (l' ++ [item], r')
-  in
-    l ++ r
-    |> List.sortWith compare
-    |> List.foldr folder ([], [])
-    |> Pivot c
+sortWith compare (Pivot c ( l, r )) =
+    let
+        folder item ( l_, r_ ) =
+            case compare item c of
+                GT ->
+                    ( l_, item :: r_ )
+
+                _ ->
+                    ( l_ ++ [ item ], r_ )
+    in
+        l
+            ++ r
+            |> List.sortWith compare
+            |> List.foldr folder ( [], [] )
+            |> Pivot c

--- a/Pivot/Position.elm
+++ b/Pivot/Position.elm
@@ -1,6 +1,4 @@
-module Pivot.Position exposing
-  (..)
-
+module Pivot.Position exposing (..)
 
 import Pivot.Types exposing (..)
 import Pivot.Utilities exposing (..)
@@ -8,60 +6,63 @@ import Pivot.Get exposing (..)
 
 
 goR : Pivot a -> Maybe (Pivot a)
-goR (Pivot cx (lt, rt)) =
-  case rt of
-    hd :: tl ->
-      Pivot hd (cx :: lt, tl)
-      |> Just
-    [] ->
-      Nothing
+goR (Pivot cx ( lt, rt )) =
+    case rt of
+        hd :: tl ->
+            Pivot hd ( cx :: lt, tl )
+                |> Just
+
+        [] ->
+            Nothing
 
 
 goL : Pivot a -> Maybe (Pivot a)
 goL =
-  goR
-  |> mirrorM
+    goR
+        |> mirrorM
 
 
 goBy : Int -> Pivot a -> Maybe (Pivot a)
 goBy steps pvt =
-  if steps == 0
-    then Just pvt
-    else if steps > 0
-      then goR pvt `Maybe.andThen` goBy (steps-1)
-      else goL pvt `Maybe.andThen` goBy (steps+1)
+    if steps == 0 then
+        Just pvt
+    else if steps > 0 then
+        goR pvt |> Maybe.andThen (goBy (steps - 1))
+    else
+        goL pvt |> Maybe.andThen (goBy (steps + 1))
 
 
 goTo : Int -> Pivot a -> Maybe (Pivot a)
 goTo dest =
-  goToStart >> goBy dest
+    goToStart >> goBy dest
 
 
 goToStart : Pivot a -> Pivot a
 goToStart pvt =
-  case goL pvt of
-    Just pvt' ->
-      goToStart pvt'
-    Nothing ->
-      pvt
+    case goL pvt of
+        Just pvt_ ->
+            goToStart pvt_
+
+        Nothing ->
+            pvt
 
 
 goToEnd : Pivot a -> Pivot a
 goToEnd =
-  goToStart
-  |> mirror
+    goToStart
+        |> mirror
 
 
 lengthL : Pivot a -> Int
 lengthL =
-  getL >> List.length
+    getL >> List.length
 
 
 lengthR : Pivot a -> Int
 lengthR =
-  getR >> List.length
+    getR >> List.length
 
 
 lengthA : Pivot a -> Int
 lengthA =
-  getA >> List.length
+    getA >> List.length

--- a/Pivot/Types.elm
+++ b/Pivot/Types.elm
@@ -1,15 +1,17 @@
-module Pivot.Types exposing
-  (..)
+module Pivot.Types exposing (..)
 
 
 type Pivot a
-  = Pivot a (Sides a)
+    = Pivot a (Sides a)
 
 
-type alias Sides a = (Left a, Right a)
+type alias Sides a =
+    ( Left a, Right a )
 
 
-type alias Left a = List a
+type alias Left a =
+    List a
 
 
-type alias Right a = List a
+type alias Right a =
+    List a

--- a/Pivot/Utilities.elm
+++ b/Pivot/Utilities.elm
@@ -1,57 +1,60 @@
-module Pivot.Utilities exposing
-  (..)
-
+module Pivot.Utilities exposing (..)
 
 import Pivot.Types exposing (..)
 
 
 reverse : Pivot a -> Pivot a
-reverse (Pivot c (l, r)) =
-  Pivot c (r, l)
+reverse (Pivot c ( l, r )) =
+    Pivot c ( r, l )
 
 
 mirror : (Pivot a -> Pivot b) -> Pivot a -> Pivot b
 mirror f =
-  reverse >> f >> reverse
+    reverse >> f >> reverse
 
 
 mirrorM : (Pivot a -> Maybe (Pivot b)) -> Pivot a -> Maybe (Pivot b)
 mirrorM f =
-  reverse >> f >> Maybe.map reverse
+    reverse >> f >> Maybe.map reverse
 
 
 assertList : List (Maybe a) -> Maybe (List a)
 assertList =
-  let
-    maybeAppend maybeVal maybeList =
-      case (maybeVal, maybeList) of
-        (Just val, Just list) ->
-          val :: list
-          |> Just
-        _ ->
-          Nothing
-  in
-    Just [] |> List.foldr maybeAppend
+    let
+        maybeAppend maybeVal maybeList =
+            case ( maybeVal, maybeList ) of
+                ( Just val, Just list ) ->
+                    val
+                        :: list
+                        |> Just
+
+                _ ->
+                    Nothing
+    in
+        Just [] |> List.foldr maybeAppend
 
 
 assert : Pivot (Maybe a) -> Maybe (Pivot a)
-assert (Pivot mc (ml, mr)) =
-  case (mc, (assertList ml, assertList mr)) of
-    (Just c, (Just l, Just r)) ->
-      Just (Pivot c (l, r))
-    _ ->
-      Nothing
+assert (Pivot mc ( ml, mr )) =
+    case ( mc, ( assertList ml, assertList mr ) ) of
+        ( Just c, ( Just l, Just r ) ) ->
+            Just (Pivot c ( l, r ))
+
+        _ ->
+            Nothing
 
 
 withRollback : (a -> Maybe a) -> a -> a
 withRollback f x =
-  f x
-  |> Maybe.withDefault x
+    f x
+        |> Maybe.withDefault x
 
 
-(!>) = flip withRollback
+(!>) =
+    flip withRollback
 infixl 0 !>
 
 
-(<!) = withRollback
+(<!) =
+    withRollback
 infixr 0 <!

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.1",
+    "version": "2.0.0",
     "summary": "Pivot: a list with a cursor pointing at the center, like a zipper.",
     "repository": "https://github.com/yotamDvir/elm-pivot.git",
     "license": "BSD3",
@@ -10,7 +10,7 @@
         "Pivot"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.4 <= v < 5.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,11 +1,11 @@
 port module Main exposing (..)
 
 import Tests
-import Test.Runner.Node exposing (run)
+import Test.Runner.Node exposing (TestProgram, run)
 import Json.Encode exposing (Value)
 
 
-main : Program Never
+main : TestProgram
 main =
     run emit Tests.all
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,15 +1,10 @@
 module Tests exposing (..)
 
-
 import Debug exposing (log)
-
-
 import Test exposing (..)
 import Expect as Ex exposing (Expectation)
 import Fuzz as Fz exposing (Fuzzer)
 import String
-
-
 import Pivot.Types as T
 import Pivot exposing (..)
 import Pivot.Utilities exposing (assertList)
@@ -17,31 +12,37 @@ import Pivot.Utilities exposing (assertList)
 
 all : Test
 all =
-  describe "Testing Pivot"
-    [ utilities
-    , create
-    , get
-    , position
-    , modify
-    ]
+    describe "Testing Pivot"
+        [ utilities
+        , create
+        , get
+        , position
+        , modify
+        ]
 
 
 toPivot : List a -> a -> List a -> Pivot a
 toPivot l c r =
-  T.Pivot c (l, r)
+    T.Pivot c ( l, r )
 
 
-fuzz' : Fuzzer a -> String -> (List a -> a -> List a -> Expectation) -> Test
-fuzz' fz =
-  fuzz3 (Fz.list fz) fz (Fz.list fz)
+fuzz_ : Fuzzer a -> String -> (List a -> a -> List a -> Expectation) -> Test
+fuzz_ fz =
+    fuzz3 (Fz.list fz) fz (Fz.list fz)
 
 
 equalIff : Bool -> a -> a -> Expectation
 equalIff should =
-  if should then Ex.equal else Ex.notEqual
+    if should then
+        Ex.equal
+    else
+        Ex.notEqual
 
 
-iff = flip equalIff
+iff =
+    flip equalIff
+
+
 
 --
 -- onPivotData : (List a -> a -> List a -> Pivot a -> Expectation) -> List a -> a -> List a -> Expectation
@@ -52,149 +53,129 @@ iff = flip equalIff
 
 utilities : Test
 utilities =
-  describe "Utilities"
-    [ fuzz' Fz.char "reverse complies with List.reverse" <|
-        \l c r ->
-          (toPivot l c r |> reverse |> getA)
-          `Ex.equal`
-          (toPivot l c r |> getA |> List.reverse)
-    , fuzz' Fz.char "mirror turns left functions into right functions" <|
-        \l c r ->
-          toPivot l c r
-          |> mirror (mapL <| always 'A')
-          |> getR
-          |> Ex.equal (flip List.map r <| always 'A')
-    , fuzz' Fz.char "mirrorM turns leftM functions into rightM functions" <|
-        \l c r ->
-          toPivot l c r
-          |> mirrorM goL
-          |> Ex.equal (
-            case r of
-              hd :: tl ->
-                toPivot (c :: l) hd tl
-                |> Just
-              [] ->
-                Nothing
-          )
-    , fuzz' (Fz.maybe Fz.unit) "assert agrees with assertList" <|
-        \l c r ->
-          (toPivot l c r |> assert |> Maybe.map getA)
-          `Ex.equal`
-          (toPivot l c r |> getA |> assertList)
-    , fuzz' (Fz.map Just Fz.unit) "assert pushes `Just` out when all values are `Just`s" <|
-        \l c r ->
-          (toPivot l c r |> assert |> Maybe.map getA)
-          `Ex.equal`
-          (toPivot l c r |> getA |> assertList)
-    ]
+    describe "Utilities"
+        [ fuzz_ Fz.char "reverse complies with List.reverse" <|
+            \l c r ->
+                Ex.equal (toPivot l c r |> reverse |> getA) (toPivot l c r |> getA |> List.reverse)
+        , fuzz_ Fz.char "mirror turns left functions into right functions" <|
+            \l c r ->
+                toPivot l c r
+                    |> mirror (mapL <| always 'A')
+                    |> getR
+                    |> Ex.equal (flip List.map r <| always 'A')
+        , fuzz_ Fz.char "mirrorM turns leftM functions into rightM functions" <|
+            \l c r ->
+                toPivot l c r
+                    |> mirrorM goL
+                    |> Ex.equal
+                        (case r of
+                            hd :: tl ->
+                                toPivot (c :: l) hd tl
+                                    |> Just
+
+                            [] ->
+                                Nothing
+                        )
+        , fuzz_ (Fz.maybe Fz.unit) "assert agrees with assertList" <|
+            \l c r ->
+                Ex.equal (toPivot l c r |> assert |> Maybe.map getA) (toPivot l c r |> getA |> assertList)
+        , fuzz_ (Fz.map Just Fz.unit) "assert pushes `Just` out when all values are `Just`s" <|
+            \l c r ->
+                Ex.equal (toPivot l c r |> assert |> Maybe.map getA) (toPivot l c r |> getA |> assertList)
+        ]
 
 
 create : Test
 create =
-  describe "Create"
-    [ fuzz (Fz.list Fz.unit) "fromList fails iff list is empty" <|
-        \list ->
-          fromList list
-          |> Nothing `iff` (List.length list == 0)
-    , fuzz (Fz.list Fz.unit) "fromCons won't have left" <|
-        \list ->
-          case list of
-            hd :: tl ->
-              fromCons hd tl
-              |> getL
-              |> Ex.equal []
-            [] ->
-              Ex.pass
-    , test "pure >> lengthA == always 1" <|
-        \_ ->
-          pure ()
-          |> lengthA
-          |> Ex.equal 1
-    ]
+    describe "Create"
+        [ fuzz (Fz.list Fz.unit) "fromList fails iff list is empty" <|
+            \list ->
+                fromList list
+                    |> iff Nothing (List.length list == 0)
+        , fuzz (Fz.list Fz.unit) "fromCons won't have left" <|
+            \list ->
+                case list of
+                    hd :: tl ->
+                        fromCons hd tl
+                            |> getL
+                            |> Ex.equal []
+
+                    [] ->
+                        Ex.pass
+        , test "singleton >> lengthA == always 1" <|
+            \_ ->
+                singleton ()
+                    |> lengthA
+                    |> Ex.equal 1
+        ]
 
 
 get : Test
 get =
-  describe "Get"
-    [ fuzz' Fz.char "getC should get center" <|
-        \l c r ->
-          toPivot l c r
-          |> getC
-          |> Ex.equal c
-    , fuzz' Fz.int "getL should get left" <|
-        \l c r ->
-          toPivot l c r
-          |> getL
-          |> Ex.equal (List.reverse l)
-    , fuzz' Fz.string "getR should get right" <|
-        \l c r ->
-          toPivot l c r
-          |> getR
-          |> Ex.equal r
-    , fuzz' Fz.char "getA == \\p -> getL p ++ [getC p] ++ getR p" <|
-        \l c r ->
-          (toPivot l c r |> \p -> getL p ++ [getC p] ++ getR p)
-          `Ex.equal`
-          (toPivot l c r |> getA)
-    , fuzz' Fz.float "hasL gives False iff no left" <|
-        \l c r ->
-          toPivot l c r
-          |> hasL
-          |> False `iff` (List.length l == 0)
-    , fuzz' Fz.unit "hasR gives False iff no right" <|
-        \l c r ->
-          toPivot l c r
-          |> hasR
-          |> False `iff` (List.length r == 0)
-    ]
+    describe "Get"
+        [ fuzz_ Fz.char "getC should get center" <|
+            \l c r ->
+                toPivot l c r
+                    |> getC
+                    |> Ex.equal c
+        , fuzz_ Fz.int "getL should get left" <|
+            \l c r ->
+                toPivot l c r
+                    |> getL
+                    |> Ex.equal (List.reverse l)
+        , fuzz_ Fz.string "getR should get right" <|
+            \l c r ->
+                toPivot l c r
+                    |> getR
+                    |> Ex.equal r
+        , fuzz_ Fz.char "getA == \\p -> getL p ++ [getC p] ++ getR p" <|
+            \l c r ->
+                Ex.equal (toPivot l c r |> \p -> getL p ++ [ getC p ] ++ getR p) (toPivot l c r |> getA)
+        , fuzz_ Fz.float "hasL gives False iff no left" <|
+            \l c r ->
+                toPivot l c r
+                    |> hasL
+                    |> iff False (List.length l == 0)
+        , fuzz_ Fz.unit "hasR gives False iff no right" <|
+            \l c r ->
+                toPivot l c r
+                    |> hasR
+                    |> iff False (List.length r == 0)
+        ]
 
 
 position : Test
 position =
-  describe "Position"
-    [ fuzz' Fz.char "goR |> Maybe.map getR == getR >> List.tail" <|
-        \l c r ->
-          (toPivot l c r |> goR |> Maybe.map getR)
-          `Ex.equal`
-          (toPivot l c r |> getR >> List.tail)
-    , fuzz' Fz.char "goR |> flip Maybe.andThen goR == goBy 2" <|
-        \l c r ->
-          (toPivot l c r |> goR |> flip Maybe.andThen goR)
-          `Ex.equal`
-          (toPivot l c r |> goBy 2)
-    , fuzz' Fz.char "goR |> flip Maybe.andThen goL == goBy 0" <|
-        \l c r ->
-          (toPivot l c r |> goR |> flip Maybe.andThen goL)
-          `Ex.equal`
-          (toPivot l c r |> goBy 0)
-    , fuzz' Fz.char "goToStart >> Just == goTo 0" <|
-        \l c r ->
-          (toPivot l c r |> goToStart >> Just)
-          `Ex.equal`
-          (toPivot l c r |> goTo 0)
-    , fuzz' Fz.char "goToStart >> getL == []" <|
-        \l c r ->
-          (toPivot l c r |> goToStart >> getL)
-          |> Ex.equal []
-    , fuzz' Fz.char "goToStart >> getR >> Just == getA >> List.tail" <|
-        \l c r ->
-          (toPivot l c r |> goToStart >> getR >> Just)
-          `Ex.equal`
-          (toPivot l c r |> getA >> List.tail)
-    ]
+    describe "Position"
+        [ fuzz_ Fz.char "goR |> Maybe.map getR == getR >> List.tail" <|
+            \l c r ->
+                Ex.equal (toPivot l c r |> goR |> Maybe.map getR) (toPivot l c r |> getR >> List.tail)
+        , fuzz_ Fz.char "goR |> Maybe.andThen goR == goBy 2" <|
+            \l c r ->
+                Ex.equal (toPivot l c r |> goR |> Maybe.andThen goR) (toPivot l c r |> goBy 2)
+        , fuzz_ Fz.char "goR |> Maybe.andThen goL == goBy 0" <|
+            \l c r ->
+                Ex.equal (toPivot l c r |> goR |> Maybe.andThen goL) (toPivot l c r |> goBy 0)
+        , fuzz_ Fz.char "goToStart >> Just == goTo 0" <|
+            \l c r ->
+                Ex.equal (toPivot l c r |> goToStart >> Just) (toPivot l c r |> goTo 0)
+        , fuzz_ Fz.char "goToStart >> getL == []" <|
+            \l c r ->
+                (toPivot l c r |> goToStart >> getL)
+                    |> Ex.equal []
+        , fuzz_ Fz.char "goToStart >> getR >> Just == getA >> List.tail" <|
+            \l c r ->
+                Ex.equal (toPivot l c r |> goToStart >> getR >> Just) (toPivot l c r |> getA >> List.tail)
+        ]
 
 
 modify : Test
 modify =
-  describe "Sort"
-    [ fuzz' Fz.char "sort >> getA == getA >> List.sort" <|
-        \l c r ->
-          (toPivot l c r |> sort >> getA)
-          `Ex.equal`
-          (toPivot l c r |> getA >> List.sort)
-    , fuzz' Fz.char "getC == sort >> getC" <|
-        \l c r ->
-          (toPivot l c r |> sort >> getC)
-          `Ex.equal`
-          (toPivot l c r |> getC)
-    ]
+    describe "Sort"
+        [ fuzz_ Fz.char "sort >> getA == getA >> List.sort" <|
+            \l c r ->
+                Ex.equal (toPivot l c r |> sort >> getA) (toPivot l c r |> getA >> List.sort)
+        , fuzz_ Fz.char "getC == sort >> getC" <|
+            \l c r ->
+                Ex.equal (toPivot l c r |> sort >> getC) (toPivot l c r |> getC)
+        ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,9 +9,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
+        "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
Fixes #3 

I ran `elm-upgrade` on the project (which ran `elm-format`), manually fixed some `'` primed functions, renamed `pure` -> `singleton`, added a `.editorconfig` to match `elm-format`. Fixed all but one test... have at it (this is my last package preventing me from upgrading to 0.18).