### PR TITLE
Benchmark and perf improvement of Pivot.Get

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/elm-stuff/
+elm-stuff/

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,2 @@
+# Generated when compiling benchmarks
+index.html

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,9 @@
+# Benchmarking functions of elm-pivot
+
+To compile a benchmark with live reload on save,
+I suggest using elm-live as follows for example:
+
+```shell
+cd benchmarks/
+elm-live src/Get.elm
+```

--- a/benchmarks/elm.json
+++ b/benchmarks/elm.json
@@ -1,0 +1,30 @@
+{
+    "type": "application",
+    "source-directories": [
+        "../src",
+        "src"
+    ],
+    "elm-version": "0.19.0",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.0",
+            "elm/core": "1.0.0",
+            "elm/html": "1.0.0",
+            "elm-explorations/benchmark": "1.0.0"
+        },
+        "indirect": {
+            "BrianHicks/elm-trend": "2.1.2",
+            "Skinney/murmur3": "2.0.8",
+            "elm/json": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "mdgriffith/style-elements": "5.0.1"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/benchmarks/src/Get.elm
+++ b/benchmarks/src/Get.elm
@@ -11,11 +11,8 @@ main =
     Benchmark.Runner.program <|
         Benchmark.describe "Pivot.Get"
             [ hasL
-            , hasLOptimized
             , hasR
-            , hasROptimized
             , getA
-            , getAOptimized
             ]
 
 
@@ -30,26 +27,11 @@ hasL =
     benchmark "hasL" (\_ -> Pivot.Get.hasL pivot1000)
 
 
-hasLOptimized : Benchmark
-hasLOptimized =
-    benchmark "hasL optimized" (\_ -> Pivot.Get.hasLOptimized pivot1000)
-
-
 hasR : Benchmark
 hasR =
     benchmark "hasR" (\_ -> Pivot.Get.hasR pivot1000)
 
 
-hasROptimized : Benchmark
-hasROptimized =
-    benchmark "hasR optimized" (\_ -> Pivot.Get.hasROptimized pivot1000)
-
-
 getA : Benchmark
 getA =
     benchmark "getA" (\_ -> Pivot.Get.getA pivot1000)
-
-
-getAOptimized : Benchmark
-getAOptimized =
-    benchmark "getA optimized" (\_ -> Pivot.Get.getAOptimized pivot1000)

--- a/benchmarks/src/Get.elm
+++ b/benchmarks/src/Get.elm
@@ -1,0 +1,55 @@
+module Get exposing (main)
+
+import Benchmark exposing (Benchmark, benchmark)
+import Benchmark.Runner exposing (BenchmarkProgram)
+import Pivot exposing (Pivot)
+import Pivot.Get
+
+
+main : BenchmarkProgram
+main =
+    Benchmark.Runner.program <|
+        Benchmark.describe "Pivot.Get"
+            [ hasL
+            , hasLOptimized
+            , hasR
+            , hasROptimized
+            , getA
+            , getAOptimized
+            ]
+
+
+pivot1000 : Pivot Int
+pivot1000 =
+    Pivot.fromCons 0 (List.repeat 999 0)
+        |> Pivot.withRollback (Pivot.goAbsolute 500)
+
+
+hasL : Benchmark
+hasL =
+    benchmark "hasL" (\_ -> Pivot.Get.hasL pivot1000)
+
+
+hasLOptimized : Benchmark
+hasLOptimized =
+    benchmark "hasL optimized" (\_ -> Pivot.Get.hasLOptimized pivot1000)
+
+
+hasR : Benchmark
+hasR =
+    benchmark "hasR" (\_ -> Pivot.Get.hasR pivot1000)
+
+
+hasROptimized : Benchmark
+hasROptimized =
+    benchmark "hasR optimized" (\_ -> Pivot.Get.hasROptimized pivot1000)
+
+
+getA : Benchmark
+getA =
+    benchmark "getA" (\_ -> Pivot.Get.getA pivot1000)
+
+
+getAOptimized : Benchmark
+getAOptimized =
+    benchmark "getA optimized" (\_ -> Pivot.Get.getAOptimized pivot1000)

--- a/benchmarks/src/Position.elm
+++ b/benchmarks/src/Position.elm
@@ -11,11 +11,8 @@ main =
     Benchmark.Runner.program <|
         Benchmark.describe "Pivot.Position"
             [ lengthL
-            , lengthLOptimized
             , lengthR
-            , lengthROptimized
             , lengthA
-            , lengthAOptimized
             ]
 
 
@@ -30,26 +27,11 @@ lengthL =
     benchmark "lengthL" (\_ -> Pivot.Position.lengthL pivot1000)
 
 
-lengthLOptimized : Benchmark
-lengthLOptimized =
-    benchmark "lengthL optimized" (\_ -> Pivot.Position.lengthLOptimized pivot1000)
-
-
 lengthR : Benchmark
 lengthR =
     benchmark "lengthR" (\_ -> Pivot.Position.lengthR pivot1000)
 
 
-lengthROptimized : Benchmark
-lengthROptimized =
-    benchmark "lengthR optimized" (\_ -> Pivot.Position.lengthROptimized pivot1000)
-
-
 lengthA : Benchmark
 lengthA =
     benchmark "lengthA" (\_ -> Pivot.Position.lengthA pivot1000)
-
-
-lengthAOptimized : Benchmark
-lengthAOptimized =
-    benchmark "lengthA optimized" (\_ -> Pivot.Position.lengthAOptimized pivot1000)

--- a/benchmarks/src/Position.elm
+++ b/benchmarks/src/Position.elm
@@ -1,0 +1,55 @@
+module Position exposing (main)
+
+import Benchmark exposing (Benchmark, benchmark)
+import Benchmark.Runner exposing (BenchmarkProgram)
+import Pivot exposing (Pivot)
+import Pivot.Position
+
+
+main : BenchmarkProgram
+main =
+    Benchmark.Runner.program <|
+        Benchmark.describe "Pivot.Position"
+            [ lengthL
+            , lengthLOptimized
+            , lengthR
+            , lengthROptimized
+            , lengthA
+            , lengthAOptimized
+            ]
+
+
+pivot1000 : Pivot Int
+pivot1000 =
+    Pivot.fromCons 0 (List.repeat 999 0)
+        |> Pivot.withRollback (Pivot.goAbsolute 500)
+
+
+lengthL : Benchmark
+lengthL =
+    benchmark "lengthL" (\_ -> Pivot.Position.lengthL pivot1000)
+
+
+lengthLOptimized : Benchmark
+lengthLOptimized =
+    benchmark "lengthL optimized" (\_ -> Pivot.Position.lengthLOptimized pivot1000)
+
+
+lengthR : Benchmark
+lengthR =
+    benchmark "lengthR" (\_ -> Pivot.Position.lengthR pivot1000)
+
+
+lengthROptimized : Benchmark
+lengthROptimized =
+    benchmark "lengthR optimized" (\_ -> Pivot.Position.lengthROptimized pivot1000)
+
+
+lengthA : Benchmark
+lengthA =
+    benchmark "lengthA" (\_ -> Pivot.Position.lengthA pivot1000)
+
+
+lengthAOptimized : Benchmark
+lengthAOptimized =
+    benchmark "lengthA optimized" (\_ -> Pivot.Position.lengthAOptimized pivot1000)

--- a/src/Pivot.elm
+++ b/src/Pivot.elm
@@ -1,70 +1,21 @@
-module Pivot
-    exposing
-        ( Pivot
-        , appendGoL
-        , appendGoR
-        , appendL
-        , appendListL
-        , appendListR
-        , appendR
-        , apply
-        , assert
-        , findCL
-        , findCR
-        , findL
-        , findR
-        , firstWith
-        , fromCons
-        , fromList
-        , getA
-        , getC
-        , getL
-        , getR
-        , goAbsolute
-        , goBy
-        , goL
-        , goR
-        , goRelative
-        , goTo
-        , goToEnd
-        , goToStart
-        , hasL
-        , hasR
-        , indexAbsolute
-        , indexRelative
-        , lastWith
-        , lengthA
-        , lengthL
-        , lengthR
-        , mapA
-        , mapC
-        , mapCLR
-        , mapCRL
-        , mapCS
-        , mapL
-        , mapR
-        , mapS
-        , mapWholeCLR
-        , mapWholeCRL
-        , mapWholeCS
-        , mapWholeL
-        , mapWholeR
-        , mapWholeS
-        , mirror
-        , mirrorM
-        , removeGoL
-        , removeGoR
-        , reverse
-        , setC
-        , setL
-        , setR
-        , singleton
-        , sort
-        , sortWith
-        , switchL
-        , switchR
-        , withRollback
-        )
+module Pivot exposing
+    ( Pivot
+    , fromList, fromCons, singleton
+    , getC, getL, getR, getA, hasL, hasR
+    , lengthL, lengthR, lengthA
+    , goR, goL, goRelative, goBy, goAbsolute, goTo, goToStart, goToEnd
+    , firstWith, lastWith, findR, findL, findCR, findCL
+    , setC, setL, setR
+    , appendL, appendR, appendGoL, appendGoR, appendListL, appendListR
+    , removeGoL, removeGoR
+    , switchL, switchR
+    , sort, sortWith
+    , mapCLR, mapCRL, mapCS, mapA, mapC, mapS, mapL, mapR
+    , mapWholeCLR, mapWholeCRL, mapWholeCS, mapWholeS, mapWholeL, mapWholeR
+    , indexAbsolute, indexRelative, apply
+    , reverse, mirror, mirrorM, assert, withRollback
+    , toList
+    )
 
 {-| A pivot is a list upgraded with a center and sides. However, a pivot
 can never be empty, so it is better to think of it an upgraded cons list.
@@ -251,7 +202,8 @@ singleton =
 
 {-| Get the center member.
 
-    getC [1 2 *3* 4] == 3
+    getC [ 1 2 * 3 * 4 ] == 3
+
     singleton >> getC == identity
 
 -}
@@ -262,7 +214,7 @@ getC =
 
 {-| Get the left side list.
 
-    getL [1 2 *3* 4] == [1, 2]
+    getL [ 1 2 * 3 * 4 ] == [ 1, 2 ]
 
 -}
 getL : Pivot a -> List a
@@ -272,7 +224,7 @@ getL =
 
 {-| Get the right side list.
 
-    getR [1 2 *3* 4] == [4]
+    getR [ 1 2 * 3 * 4 ] == [ 4 ]
 
 -}
 getR : Pivot a -> List a
@@ -282,7 +234,7 @@ getR =
 
 {-| Make the pivot into a list.
 
-    getA [1 2 *3* 4] == [1, 2, 3, 4]
+    getA [ 1 2 * 3 * 4 ] == [ 1, 2, 3, 4 ]
 
 -}
 getA : Pivot a -> List a
@@ -335,7 +287,7 @@ lastWith =
 
 _Fails if and only if there are no such members._
 
-    findR ((==) 3) [1 2 *3* 4] == Nothing
+    findR ((==) 3) [ 1 2 * 3 * 4 ] == Nothing
 
 -}
 findR : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
@@ -347,7 +299,7 @@ findR =
 
 _Fails if and only if there are no such members._
 
-    findL ((==) 2) [1 2 *3* 4] == Just [1 *2* 3 4]
+    findL ((==) 2) [ 1 2 * 3 * 4 ] == Just [ 1 * 2 * 3 4 ]
 
 -}
 findL : (a -> Bool) -> Pivot a -> Maybe (Pivot a)
@@ -359,7 +311,8 @@ findL =
 
 _Fails if and only if there are no such members._
 
-    findCR ((==) 3) [1 2 *3* 4] == Just [1 2 *3* 4]
+    findCR ((==) 3) [ 1 2 * 3 * 4 ] == Just [ 1 2 * 3 * 4 ]
+
     firstWith pred == goToStart >> findCR pred
 
 -}
@@ -577,7 +530,7 @@ appendGoR =
 
 {-| Like `List.append`, but the right side is a pivot.
 
-    appendListL [8, 9] [1 2 *3* 4] == [8 9 1 2 *3* 4]
+    appendListL [ 8, 9 ] [ 1 2 * 3 * 4 ] == [ 8 9 1 2 * 3 * 4 ]
 
 -}
 appendListL : List a -> Pivot a -> Pivot a
@@ -587,7 +540,7 @@ appendListL =
 
 {-| Like `List.append`, but the left side is a pivot.
 
-    appendListR [8, 9] [1 2 *3* 4] == [1 2 *3* 4 8 9]
+    appendListR [ 8, 9 ] [ 1 2 * 3 * 4 ] == [ 1 2 * 3 * 4 8 9 ]
 
 -}
 appendListR : List a -> Pivot a -> Pivot a
@@ -600,6 +553,7 @@ appendListR =
 It does not simply sort each side separately!
 
     sort >> getA == getA >> List.sort
+
     getC == sort >> getC
 
 -}
@@ -644,7 +598,7 @@ mapCS =
 {-| Like `mapCS`, but you provide one function for all members.
 This is exactly like `List.map` for the underlying list.
 
-    mapA ((==) 3) [1 *2* 3 4] == [False *False* True False]
+    mapA ((==) 3) [ 1 * 2 * 3 4 ] == [ False * False * True False ]
 
 -}
 mapA : (a -> b) -> Pivot a -> Pivot b
@@ -684,7 +638,7 @@ mapS =
 lists as a whole, and not on each member separately.
 The lists are ordered from the center out.
 
-    mapWholeCLR ((*) 3) (List.drop 1) (List.drop 1) [1 2 *3* 4 5] == [1 *9* 5]
+    mapWholeCLR ((*) 3) (List.drop 1) (List.drop 1) [ 1 2 * 3 * 4 5 ] == [ 1 * 9 * 5 ]
 
 -}
 mapWholeCLR : (a -> b) -> (List a -> List b) -> (List a -> List b) -> Pivot a -> Pivot b
@@ -730,7 +684,7 @@ mapWholeS =
 {-| Adds indices to all values, from left to right.
 Based internally on `List.indexedMap`.
 
-    indexAbsolute [1 2 *3* 4] == [(0,1) (1,2) *(2,3)* (3,4)]
+    indexAbsolute [ 1 2 * 3 * 4 ] == [ ( 0, 1 ) ( 1, 2 ) * ( 2, 3 ) * ( 3, 4 ) ]
 
 -}
 indexAbsolute : Pivot a -> Pivot ( Int, a )
@@ -740,7 +694,7 @@ indexAbsolute =
 
 {-| Like `indexAbsolute`, but relative to the center (that gets the index 0).
 
-    indexAbsolute [1 2 *3* 4] == [(-2,1) (-1,2) *(0,3)* (1,4)]
+    indexAbsolute [ 1 2 * 3 * 4 ] == [ ( -2, 1 ) ( -1, 2 ) * ( 0, 3 ) * ( 1, 4 ) ]
 
 -}
 indexRelative : Pivot a -> Pivot ( Int, a )
@@ -755,7 +709,7 @@ But how does a list of functions get applied on a list of values?
 Well, each function maps over the complete list of values,
 and then all the lists created from these applications are concatinated.
 
-    mapCLR onC onL onR == apply [onL *onC* onR]
+    mapCLR onC onL onR == apply [ onL * onC * onR ]
 
 -}
 apply : Pivot (a -> b) -> Pivot a -> Pivot b

--- a/src/Pivot/Create.elm
+++ b/src/Pivot/Create.elm
@@ -1,9 +1,4 @@
-module Pivot.Create
-    exposing
-        ( fromCons
-        , fromList
-        , singleton
-        )
+module Pivot.Create exposing (fromCons, fromList, singleton)
 
 import Pivot.Get exposing (..)
 import Pivot.Types exposing (..)

--- a/src/Pivot/Find.elm
+++ b/src/Pivot/Find.elm
@@ -1,12 +1,4 @@
-module Pivot.Find
-    exposing
-        ( findCL
-        , findCR
-        , findL
-        , findR
-        , firstWith
-        , lastWith
-        )
+module Pivot.Find exposing (findCL, findCR, findL, findR, firstWith, lastWith)
 
 import Pivot.Get exposing (..)
 import Pivot.Position exposing (..)

--- a/src/Pivot/Get.elm
+++ b/src/Pivot/Get.elm
@@ -1,4 +1,4 @@
-module Pivot.Get exposing (..)
+module Pivot.Get exposing (getA, getAOptimized, getC, getL, getR, hasL, hasLOptimized, hasR, hasROptimized)
 
 import Pivot.Types exposing (..)
 import Pivot.Utilities exposing (..)

--- a/src/Pivot/Get.elm
+++ b/src/Pivot/Get.elm
@@ -19,6 +19,11 @@ hasL =
     getL >> List.isEmpty >> not
 
 
+hasLOptimized : Pivot a -> Bool
+hasLOptimized (Pivot _ ( l, _ )) =
+    not (List.isEmpty l)
+
+
 getR : Pivot a -> List a
 getR (Pivot _ ( _, r )) =
     r
@@ -29,6 +34,26 @@ hasR =
     getR >> List.isEmpty >> not
 
 
+hasROptimized : Pivot a -> Bool
+hasROptimized (Pivot _ ( _, r )) =
+    not (List.isEmpty r)
+
+
 getA : Pivot a -> List a
 getA (Pivot c ( l, r )) =
     List.reverse l ++ c :: r
+
+
+getAOptimized : Pivot a -> List a
+getAOptimized (Pivot c ( l, r )) =
+    reversePrepend l (c :: r)
+
+
+reversePrepend : List a -> List a -> List a
+reversePrepend l1 l2 =
+    case l1 of
+        l :: ls ->
+            reversePrepend ls (l :: l2)
+
+        _ ->
+            l2

--- a/src/Pivot/Get.elm
+++ b/src/Pivot/Get.elm
@@ -46,14 +46,4 @@ getA (Pivot c ( l, r )) =
 
 getAOptimized : Pivot a -> List a
 getAOptimized (Pivot c ( l, r )) =
-    reversePrepend l (c :: r)
-
-
-reversePrepend : List a -> List a -> List a
-reversePrepend l1 l2 =
-    case l1 of
-        l :: ls ->
-            reversePrepend ls (l :: l2)
-
-        _ ->
-            l2
+    reversePrependList l (c :: r)

--- a/src/Pivot/Get.elm
+++ b/src/Pivot/Get.elm
@@ -1,4 +1,4 @@
-module Pivot.Get exposing (getA, getAOptimized, getC, getL, getR, hasL, hasLOptimized, hasR, hasROptimized)
+module Pivot.Get exposing (getA, getC, getL, getR, hasL, hasR)
 
 import Pivot.Types exposing (..)
 import Pivot.Utilities exposing (..)
@@ -15,12 +15,7 @@ getL (Pivot _ ( l, _ )) =
 
 
 hasL : Pivot a -> Bool
-hasL =
-    getL >> List.isEmpty >> not
-
-
-hasLOptimized : Pivot a -> Bool
-hasLOptimized (Pivot _ ( l, _ )) =
+hasL (Pivot _ ( l, _ )) =
     not (List.isEmpty l)
 
 
@@ -30,20 +25,10 @@ getR (Pivot _ ( _, r )) =
 
 
 hasR : Pivot a -> Bool
-hasR =
-    getR >> List.isEmpty >> not
-
-
-hasROptimized : Pivot a -> Bool
-hasROptimized (Pivot _ ( _, r )) =
+hasR (Pivot _ ( _, r )) =
     not (List.isEmpty r)
 
 
 getA : Pivot a -> List a
 getA (Pivot c ( l, r )) =
-    List.reverse l ++ c :: r
-
-
-getAOptimized : Pivot a -> List a
-getAOptimized (Pivot c ( l, r )) =
     reversePrependList l (c :: r)

--- a/src/Pivot/Map.elm
+++ b/src/Pivot/Map.elm
@@ -1,23 +1,4 @@
-module Pivot.Map
-    exposing
-        ( apply
-        , indexAbsolute
-        , indexRelative
-        , mapA
-        , mapC
-        , mapCLR
-        , mapCRL
-        , mapCS
-        , mapL
-        , mapR
-        , mapS
-        , mapWholeCLR
-        , mapWholeCRL
-        , mapWholeCS
-        , mapWholeL
-        , mapWholeR
-        , mapWholeS
-        )
+module Pivot.Map exposing (apply, indexAbsolute, indexRelative, mapA, mapC, mapCLR, mapCRL, mapCS, mapL, mapR, mapS, mapWholeCLR, mapWholeCRL, mapWholeCS, mapWholeL, mapWholeR, mapWholeS)
 
 import Pivot.Get exposing (..)
 import Pivot.Position exposing (..)

--- a/src/Pivot/Modify.elm
+++ b/src/Pivot/Modify.elm
@@ -1,21 +1,4 @@
-module Pivot.Modify
-    exposing
-        ( appendGoL
-        , appendGoR
-        , appendL
-        , appendListL
-        , appendListR
-        , appendR
-        , removeGoL
-        , removeGoR
-        , setC
-        , setL
-        , setR
-        , sort
-        , sortWith
-        , switchL
-        , switchR
-        )
+module Pivot.Modify exposing (appendGoL, appendGoR, appendL, appendListL, appendListR, appendR, removeGoL, removeGoR, setC, setL, setR, sort, sortWith, switchL, switchR)
 
 import Pivot.Create exposing (..)
 import Pivot.Get exposing (..)

--- a/src/Pivot/Position.elm
+++ b/src/Pivot/Position.elm
@@ -1,15 +1,4 @@
-module Pivot.Position
-    exposing
-        ( goAbsolute
-        , goL
-        , goR
-        , goRelative
-        , goToEnd
-        , goToStart
-        , lengthA
-        , lengthL
-        , lengthR
-        )
+module Pivot.Position exposing (goAbsolute, goL, goR, goRelative, goToEnd, goToStart, lengthA, lengthAOptimized, lengthL, lengthLOptimized, lengthR, lengthROptimized)
 
 import Pivot.Get exposing (..)
 import Pivot.Types exposing (..)
@@ -68,11 +57,26 @@ lengthL =
     getL >> List.length
 
 
+lengthLOptimized : Pivot a -> Int
+lengthLOptimized (Pivot _ ( l, _ )) =
+    List.length l
+
+
 lengthR : Pivot a -> Int
 lengthR =
     getR >> List.length
 
 
+lengthROptimized : Pivot a -> Int
+lengthROptimized (Pivot _ ( _, r )) =
+    List.length r
+
+
 lengthA : Pivot a -> Int
 lengthA =
     getA >> List.length
+
+
+lengthAOptimized : Pivot a -> Int
+lengthAOptimized (Pivot _ ( l, r )) =
+    List.length l + 1 + List.length r

--- a/src/Pivot/Position.elm
+++ b/src/Pivot/Position.elm
@@ -1,4 +1,4 @@
-module Pivot.Position exposing (goAbsolute, goL, goR, goRelative, goToEnd, goToStart, lengthA, lengthAOptimized, lengthL, lengthLOptimized, lengthR, lengthROptimized)
+module Pivot.Position exposing (goAbsolute, goL, goR, goRelative, goToEnd, goToStart, lengthA, lengthL, lengthR)
 
 import Pivot.Get exposing (..)
 import Pivot.Types exposing (..)
@@ -53,30 +53,15 @@ goToEnd =
 
 
 lengthL : Pivot a -> Int
-lengthL =
-    getL >> List.length
-
-
-lengthLOptimized : Pivot a -> Int
-lengthLOptimized (Pivot _ ( l, _ )) =
+lengthL (Pivot _ ( l, _ )) =
     List.length l
 
 
 lengthR : Pivot a -> Int
-lengthR =
-    getR >> List.length
-
-
-lengthROptimized : Pivot a -> Int
-lengthROptimized (Pivot _ ( _, r )) =
+lengthR (Pivot _ ( _, r )) =
     List.length r
 
 
 lengthA : Pivot a -> Int
-lengthA =
-    getA >> List.length
-
-
-lengthAOptimized : Pivot a -> Int
-lengthAOptimized (Pivot _ ( l, r )) =
+lengthA (Pivot _ ( l, r )) =
     List.length l + 1 + List.length r

--- a/src/Pivot/Types.elm
+++ b/src/Pivot/Types.elm
@@ -1,4 +1,4 @@
-module Pivot.Types exposing (..)
+module Pivot.Types exposing (Left, Pivot(..), Right, Sides)
 
 
 type Pivot a

--- a/src/Pivot/Utilities.elm
+++ b/src/Pivot/Utilities.elm
@@ -1,12 +1,4 @@
-module Pivot.Utilities
-    exposing
-        ( assert
-        , mirror
-        , mirrorM
-        , reverse
-        , reversePrependList
-        , withRollback
-        )
+module Pivot.Utilities exposing (assert, assertList, mirror, mirrorM, reverse, reversePrependList, withRollback)
 
 import Pivot.Types exposing (..)
 

--- a/src/Pivot/Utilities.elm
+++ b/src/Pivot/Utilities.elm
@@ -4,6 +4,7 @@ module Pivot.Utilities
         , mirror
         , mirrorM
         , reverse
+        , reversePrependList
         , withRollback
         )
 
@@ -52,3 +53,13 @@ assert (Pivot mc ( ml, mr )) =
 withRollback : (a -> Maybe a) -> a -> a
 withRollback f x =
     f x |> Maybe.withDefault x
+
+
+reversePrependList : List a -> List a -> List a
+reversePrependList l r =
+    case l of
+        x :: xs ->
+            reversePrependList xs (x :: r)
+
+        _ ->
+            r


### PR DESCRIPTION
Hi, I was using elm-pivot last year but eventually made my own smaller local zipper for mainly two reasons:

* to reduce bundle size (doesn't make sense anymore with DCE in 0.19)
* because the `hasL` function had a big perf cost (due to use of `getL`)

I figured I could contribute back with some small internal change of `Pivot.Get` functions. I added benchmarks to make sure I wasn't blindly worsening them. In firefox, I'm getting the results depicted in the following image. Let me know what you think.

![pivot-benchmark](https://user-images.githubusercontent.com/2905865/46403894-4f748d80-c736-11e8-8732-d14985bf8540.png)
